### PR TITLE
fix: Portainer scratch based image used as source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM portainer/portainer-ce:2.6.3-alpine as portainer
+FROM portainer/portainer-ce:2.6.3 as portainer
 
 FROM homecentr/base:3.2.0-alpine
 


### PR DESCRIPTION
Using alpine based image then copies all files (e.g. also Alpine packages) from Portainer image which may not always be up to date.