### PR TITLE
Fix(deps): Portainer 2.9.0 released

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM portainer/portainer-ce:2.6.3 as portainer
+FROM portainer/portainer-ce:2.9.0-alpine as portainer
 
 FROM homecentr/base:3.2.0-alpine
 


### PR DESCRIPTION
Released Portainer 2.9.0, and available as an alpine image.